### PR TITLE
Improve nearest truck algorithm

### DIFF
--- a/webapp/backend/src/domains/auth_service.rs
+++ b/webapp/backend/src/domains/auth_service.rs
@@ -1,7 +1,7 @@
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::io;
 
 use actix_web::web::Bytes;
 use log::error;

--- a/webapp/backend/src/domains/tow_truck_service.rs
+++ b/webapp/backend/src/domains/tow_truck_service.rs
@@ -100,10 +100,12 @@ impl<
             graph.add_edge(edge);
         }
 
+        let distances = graph.dijkstra(order.node_id);
+
         let tow_trucks_with_distance: Vec<_> = tow_trucks
             .into_iter()
             .map(|truck| {
-                let distance = calculate_distance(&graph, truck.node_id, order.node_id);
+                let distance = distances.get(&truck.node_id).unwrap().clone();
                 (distance, truck)
             })
             .collect();
@@ -121,8 +123,4 @@ impl<
             None => Ok(None),
         }
     }
-}
-
-fn calculate_distance(graph: &Graph, node_id_1: i32, node_id_2: i32) -> i32 {
-    graph.shortest_path(node_id_1, node_id_2)
 }

--- a/webapp/backend/src/domains/tow_truck_service.rs
+++ b/webapp/backend/src/domains/tow_truck_service.rs
@@ -100,30 +100,26 @@ impl<
             graph.add_edge(edge);
         }
 
-        let sorted_tow_trucks_by_distance = {
-            let mut tow_trucks_with_distance: Vec<_> = tow_trucks
-                .into_iter()
-                .map(|truck| {
-                    let distance = calculate_distance(&graph, truck.node_id, order.node_id);
-                    (distance, truck)
-                })
-                .collect();
-
-            tow_trucks_with_distance.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-            tow_trucks_with_distance
-        };
-
-        if sorted_tow_trucks_by_distance.is_empty() || sorted_tow_trucks_by_distance[0].0 > 10000000
-        {
-            return Ok(None);
-        }
-
-        let sorted_tow_truck_dtos: Vec<TowTruckDto> = sorted_tow_trucks_by_distance
+        let tow_trucks_with_distance: Vec<_> = tow_trucks
             .into_iter()
-            .map(|(_, truck)| TowTruckDto::from_entity(truck))
+            .map(|truck| {
+                let distance = calculate_distance(&graph, truck.node_id, order.node_id);
+                (distance, truck)
+            })
             .collect();
 
-        Ok(sorted_tow_truck_dtos.first().cloned())
+        let nearest_tow_truck = tow_trucks_with_distance.iter().min_by_key(|t| t.0);
+
+        match nearest_tow_truck {
+            Some(max_truck) => {
+                if max_truck.0 > 10000000 {
+                    return Ok(None);
+                }
+                let tow_truck_dto = TowTruckDto::from_entity(max_truck.1.clone());
+                Ok(Some(tow_truck_dto))
+            }
+            None => Ok(None),
+        }
     }
 }
 

--- a/webapp/backend/src/models/graph.rs
+++ b/webapp/backend/src/models/graph.rs
@@ -1,5 +1,6 @@
 use sqlx::FromRow;
-use std::collections::HashMap;
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
 
 #[derive(FromRow, Clone, Debug)]
 pub struct Node {
@@ -50,27 +51,60 @@ impl Graph {
             .push(reverse_edge);
     }
 
-    pub fn shortest_path(&self, from_node_id: i32, to_node_id: i32) -> i32 {
-        let mut distances = HashMap::new();
-        distances.insert(from_node_id, 0);
+    pub fn dijkstra(&self, start: i32) -> HashMap<i32, i32> {
+        let mut distances: HashMap<i32, i32> =
+            self.nodes.keys().map(|&node| (node, i32::MAX)).collect();
+        let mut heap = BinaryHeap::new();
 
-        for _ in 0..self.nodes.len() {
-            for node_id in self.nodes.keys() {
-                if let Some(edges) = self.edges.get(node_id) {
-                    for edge in edges {
-                        let new_distance = distances
-                            .get(node_id)
-                            .and_then(|d: &i32| d.checked_add(edge.weight))
-                            .unwrap_or(i32::MAX);
-                        let current_distance = distances.get(&edge.node_b_id).unwrap_or(&i32::MAX);
-                        if new_distance < *current_distance {
-                            distances.insert(edge.node_b_id, new_distance);
-                        }
+        distances.insert(start, 0);
+        heap.push(State {
+            cost: 0,
+            position: start,
+        });
+
+        while let Some(State { cost, position }) = heap.pop() {
+            if cost > *distances.get(&position).unwrap() {
+                continue;
+            }
+
+            if let Some(neighbors) = self.edges.get(&position) {
+                for edge in neighbors {
+                    let next = State {
+                        cost: cost + edge.weight,
+                        position: edge.node_b_id,
+                    };
+
+                    if next.cost < *distances.get(&edge.node_b_id).unwrap() {
+                        heap.push(next);
+                        distances.insert(edge.node_b_id, next.cost);
                     }
                 }
             }
         }
 
-        distances.get(&to_node_id).cloned().unwrap_or(i32::MAX)
+        distances
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct State {
+    cost: i32,
+    position: i32,
+}
+
+// The priority queue depends on `Ord`.
+impl Ord for State {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .cost
+            .cmp(&self.cost) // Notice that the we flip the ordering on costs.
+            .then_with(|| self.position.cmp(&other.position))
+    }
+}
+
+// `PartialOrd` needs to be implemented as well.
+impl PartialOrd for State {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }


### PR DESCRIPTION
LOCAL

```
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+----------+-------+--------+--------+--------+--------+-------------+-------------+---------------+-------------+
| COUNT | 1XX | 2XX | 3XX | 4XX | 5XX | METHOD |                              URI                               |  MIN  |  MAX   |   SUM    |  AVG  |  P90   |  P95   |  P99   | STDDEV |  MIN(BODY)  |  MAX(BODY)  |   SUM(BODY)   |  AVG(BODY)  |
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+----------+-------+--------+--------+--------+--------+-------------+-------------+---------------+-------------+
| 197   | 197 | 0   | 0   | 0   | 0   | GET    | /_next/webpack-hmr                                             | 0.488 | 39.498 | 1909.105 | 9.691 | 31.507 | 36.363 | 38.215 | 12.254 | 156.000     | 4992.000    | 138985.000    | 705.508     |
| 181   | 0   | 128 | 0   | 35  | 18  | POST   | /api/login                                                     | 0.001 | 29.872 | 398.488  | 2.202 | 0.877  | 29.832 | 29.861 | 7.046  | 26.000      | 559.000     | 29413.000     | 162.503     |
| 40    | 0   | 11  | 0   | 13  | 16  | POST   | /api/register                                                  | 0.001 | 29.991 | 59.641   | 1.491 | 0.605  | 0.746  | 29.991 | 5.897  | 25.000      | 559.000     | 11279.000     | 281.975     |
| 256   | 0   | 247 | 0   | 2   | 7   | GET    | /api/order/[0-9]*                                              | 0.001 | 60.006 | 282.196  | 1.102 | 0.030  | 0.278  | 60.002 | 7.238  | 24.000      | 7304.000    | 507249.000    | 1981.441    |
| 122   | 0   | 109 | 0   | 13  | 0   | GET    | /api/tow_truck/nearest                                         | 0.008 | 5.079  | 82.002   | 0.672 | 1.845  | 5.067  | 5.078  | 1.302  | 49.000      | 115.000     | 12387.000     | 101.533     |
| 210   | 0   | 207 | 0   | 3   | 0   | GET    | /orders                                                        | 0.012 | 29.802 | 103.071  | 0.491 | 0.084  | 0.303  | 29.774 | 3.533  | 104.000     | 1357.000    | 146742.000    | 698.771     |
| 978   | 0   | 959 | 0   | 13  | 6   | GET    | /api/user_image/*                                              | 0.001 | 33.078 | 219.942  | 0.225 | 0.021  | 0.095  | 3.721  | 2.404  | 23.000      | 164943.000  | 143386506.000 | 146611.969  |
| 601   | 0   | 598 | 0   | 3   | 0   | GET    | /orders/[0-9]*                                                 | 0.001 | 29.818 | 119.819  | 0.199 | 0.110  | 0.135  | 0.354  | 2.098  | 123.000     | 1111320.000 | 221398949.000 | 368384.275  |
| 198   | 0   | 198 | 0   | 0   | 0   | GET    | /_next/static/chunks/main-app.js                               | 0.104 | 0.462  | 39.190   | 0.198 | 0.340  | 0.396  | 0.456  | 0.090  | 1343274.000 | 1343337.000 | 265976555.000 | 1343315.934 |
| 198   | 0   | 198 | 0   | 0   | 0   | GET    | /_next/static/chunks/app/login/page.js                         | 0.051 | 0.367  | 21.947   | 0.111 | 0.207  | 0.246  | 0.365  | 0.066  | 886307.000  | 886394.000  | 175500256.000 | 886364.929  |
| 30    | 0   | 30  | 0   | 0   | 0   | GET    | /api/tow_truck/list                                            | 0.003 | 0.341  | 3.243    | 0.108 | 0.286  | 0.289  | 0.341  | 0.130  | 870.000     | 184496.000  | 1131072.000   | 37702.400   |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.3f295d89aa78ef9a.hot-update.js   | 0.071 | 0.071  | 0.071    | 0.071 | 0.071  | 0.071  | 0.071  | 0.000  | 858.000     | 858.000     | 858.000       | 858.000     |
| 139   | 0   | 94  | 0   | 45  | 0   | POST   | /api/order/[0-9]*                                              | 0.001 | 3.727  | 7.288    | 0.052 | 0.022  | 0.143  | 0.804  | 0.326  | 0.000       | 72.000      | 1671.000      | 12.022      |
| 181   | 0   | 181 | 0   | 0   | 0   | GET    | /_next/static/chunks/app/page.js                               | 0.029 | 0.178  | 9.221    | 0.051 | 0.078  | 0.087  | 0.164  | 0.023  | 490371.000  | 490426.000  | 88763501.000  | 490406.083  |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.92c248517bb20d80.hot-update.js   | 0.036 | 0.036  | 0.036    | 0.036 | 0.036  | 0.036  | 0.036  | 0.000  | 858.000     | 858.000     | 858.000       | 858.000     |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.681e8a45eacbb3cc.hot-update.js   | 0.033 | 0.033  | 0.033    | 0.033 | 0.033  | 0.033  | 0.033  | 0.000  | 858.000     | 858.000     | 858.000       | 858.000     |
| 198   | 0   | 198 | 0   | 0   | 0   | GET    | /_next/static/chunks/app/layout.js                             | 0.015 | 0.164  | 6.456    | 0.033 | 0.053  | 0.061  | 0.150  | 0.019  | 164110.000  | 164165.000  | 32499356.000  | 164138.162  |
| 286   | 0   | 286 | 0   | 0   | 0   | GET    | /                                                              | 0.011 | 0.666  | 7.977    | 0.028 | 0.041  | 0.052  | 0.159  | 0.043  | 88.000      | 2383.000    | 239624.000    | 837.846     |
| 274   | 0   | 274 | 0   | 0   | 0   | GET    | /login                                                         | 0.007 | 1.602  | 6.947    | 0.025 | 0.037  | 0.047  | 0.070  | 0.096  | 103.000     | 2435.000    | 352410.000    | 1286.168    |
| 76    | 0   | 76  | 0   | 0   | 0   | POST   | /api/logout                                                    | 0.002 | 1.282  | 1.776    | 0.023 | 0.012  | 0.015  | 1.282  | 0.145  | 0.000       | 0.000       | 0.000         | 0.000       |
| 152   | 0   | 152 | 0   | 0   | 0   | GET    | /session                                                       | 0.005 | 0.134  | 2.707    | 0.018 | 0.034  | 0.047  | 0.084  | 0.016  | 156.000     | 157.000     | 23752.000     | 156.263     |
| 105   | 0   | 105 | 0   | 0   | 0   | POST   | /session                                                       | 0.005 | 0.284  | 1.653    | 0.016 | 0.022  | 0.028  | 0.094  | 0.028  | 48.000      | 48.000      | 5040.000      | 48.000      |
| 198   | 0   | 198 | 0   | 0   | 0   | GET    | /_next/static/chunks/app/error.js                              | 0.004 | 0.127  | 2.787    | 0.014 | 0.024  | 0.030  | 0.038  | 0.011  | 37328.000   | 37367.000   | 7396066.000   | 37353.869   |
| 76    | 0   | 76  | 0   | 0   | 0   | DELETE | /session                                                       | 0.006 | 0.111  | 1.030    | 0.014 | 0.026  | 0.035  | 0.111  | 0.014  | 51.000      | 51.000      | 3876.000      | 51.000      |
| 198   | 0   | 198 | 0   | 0   | 0   | GET    | /_next/static/chunks/app-pages-internals.js                    | 0.004 | 0.127  | 2.474    | 0.012 | 0.022  | 0.029  | 0.101  | 0.013  | 31285.000   | 31323.000   | 6200180.000   | 31314.040   |
| 198   | 0   | 198 | 0   | 0   | 0   | GET    | /_next/static/chunks/webpack.js                                | 0.002 | 0.032  | 1.353    | 0.007 | 0.013  | 0.018  | 0.031  | 0.005  | 10538.000   | 10552.000   | 2087565.000   | 10543.258   |
| 9     | 0   | 9   | 0   | 0   | 0   | GET    | /__nextjs_original-stack-frame                                 | 0.003 | 0.016  | 0.060    | 0.007 | 0.016  | 0.016  | 0.016  | 0.005  | 395.000     | 959.000     | 6705.000      | 745.000     |
| 198   | 0   | 198 | 0   | 0   | 0   | GET    | /_next/static/css/app/layout.css                               | 0.001 | 0.030  | 1.089    | 0.005 | 0.012  | 0.016  | 0.024  | 0.005  | 1560.000    | 1560.000    | 308880.000    | 1560.000    |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/3f295d89aa78ef9a.webpack.hot-update.json | 0.005 | 0.005  | 0.005    | 0.005 | 0.005  | 0.005  | 0.005  | 0.000  | 31.000      | 31.000      | 31.000        | 31.000      |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/92c248517bb20d80.webpack.hot-update.json | 0.005 | 0.005  | 0.005    | 0.005 | 0.005  | 0.005  | 0.005  | 0.000  | 31.000      | 31.000      | 31.000        | 31.000      |
| 122   | 0   | 122 | 0   | 0   | 0   | GET    | /_next/static/media/c9a5bc6a7c948fb0-s.p.woff2                 | 0.001 | 0.021  | 0.562    | 0.005 | 0.009  | 0.010  | 0.020  | 0.004  | 46552.000   | 46552.000   | 5679344.000   | 46552.000   |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/681e8a45eacbb3cc.webpack.hot-update.json | 0.004 | 0.004  | 0.004    | 0.004 | 0.004  | 0.004  | 0.004  | 0.000  | 31.000      | 31.000      | 31.000        | 31.000      |
| 18    | 0   | 18  | 0   | 0   | 0   | PUT    | /api/map/update_edge                                           | 0.001 | 0.003  | 0.033    | 0.002 | 0.002  | 0.003  | 0.003  | 0.000  | 0.000       | 0.000       | 0.000         | 0.000       |
| 54    | 0   | 54  | 0   | 0   | 0   | POST   | /api/tow_truck/location                                        | 0.001 | 0.003  | 0.096    | 0.002 | 0.003  | 0.003  | 0.003  | 0.001  | 0.000       | 0.000       | 0.000         | 0.000       |
| 18    | 0   | 18  | 0   | 0   | 0   | GET    | /api/tow_truck/1                                               | 0.001 | 0.002  | 0.026    | 0.001 | 0.002  | 0.002  | 0.002  | 0.000  | 102.000     | 102.000     | 1836.000      | 102.000     |
| 6     | 0   | 0   | 0   | 6   | 0   | GET    | /api/tow_truck/100000000                                       | 0.001 | 0.002  | 0.007    | 0.001 | 0.002  | 0.002  | 0.002  | 0.000  | 0.000       | 0.000       | 0.000         | 0.000       |
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+----------+-------+--------+--------+--------+--------+-------------+-------------+---------------+-------------+
```

```
# 650ms user time, 40ms system time, 35.17M rss, 391.46G vsz
# Current date: Sat Jul 27 15:16:28 2024
# Hostname: MacBook.local
# Files: slow.log
# Overall: 13.30k total, 81 unique, 59.13 QPS, 0.02x concurrency _________
# Time range: 2024-07-27T06:11:55 to 2024-07-27T06:15:40
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time             5s     1us   314ms   362us   366us     6ms    20us
# Lock time            4ms       0    62us       0     1us     1us       0
# Rows sent        380.43k       0  48.83k   29.28    0.99  964.03       0
# Rows examine      17.55M       0   2.49M   1.35k    0.99  37.51k       0
# Query size         4.73M       6   7.63k  372.91   2.27k 1020.71   51.63

# Profile
# Rank Query ID                            Response time Calls R/Call V/M 
# ==== =================================== ============= ===== ====== ====
#    1 0x908FF3EE414069FBDFE9FF90701E227F   1.2837 26.6%    36 0.0357  0.04 SELECT tow_trucks users locations
#    2 0xF3D90F2F70D70848EA75F9D3300BF7BD   0.6723 14.0%    34 0.0198  0.14 SELECT edges nodes
#    3 0x6B1CA44888341BCBADC7E7D6C44D41B5   0.4336  9.0%    38 0.0114  0.21 INSERT sessions
#    4 0x7DFA2D5D9DBC803F79DB97773EC5447B   0.3273  6.8%  1696 0.0002  0.00 INSERT time_zone_transition
#    5 0x77DFA104A9A4D9D12635A7A0CBE1309A   0.2853  5.9%     1 0.2853  0.00 LOAD DATA users
#    6 0xA361BBE6FFE611739E98EE96EB35491C   0.2600  5.4%     1 0.2600  0.00 SELECT tow_trucks users locations
#    7 0x422658A0BB67F143CA920D09BAB4918B   0.2368  4.9%     1 0.2368  0.00 LOAD DATA edges
#    8 0x135A2BFECAE321BE61BF48B520717C62   0.2314  4.8%     1 0.2314  0.00 SELECT tow_trucks users locations
#    9 0x8A3E4B6435519E43C2B8B8E135E99668   0.1025  2.1%    33 0.0031  0.00 INSERT completed_orders
#   10 0x04BBD25509FE01B133EB50DCE5E01990   0.1022  2.1%    26 0.0039  0.00 DELETE sessions
#   11 0xD54A281FB93595B0456A5C68CBA58B59   0.0859  1.8%    34 0.0025  0.00 SELECT nodes
#   12 0xE8390778DC20D4CC04FE01C5B31FD305   0.0724  1.5%  2264 0.0000  0.00 ADMIN PING
#   13 0x93B0490C6027E6D67E3D4DA357148667   0.0657  1.4%  1792 0.0000  0.00 INSERT time_zone_transition_type
#   14 0xB16EDE898E3C0ED14B8EF7512C77E37E   0.0585  1.2%     1 0.0585  0.00 LOAD DATA nodes
#   15 0x45DCEA13C4252CE30BAABA0BACD76CBC   0.0523  1.1%    27 0.0019  0.00 UPDATE orders
#   16 0xC723F48BCC895E734B69049287D2F63C   0.0500  1.0%    27 0.0019  0.00 UPDATE tow_trucks
#   17 0xA0E74157814D3B028858FEF1E6A316B6   0.0487  1.0%   302 0.0002  0.00 SELECT users
#   18 0x0FFC9A8A5EF9B73B88FBD85709817AC6   0.0352  0.7%    33 0.0011  0.00 SELECT orders nodes
#   19 0xDA556F9115773A1A99AA0165670CE848   0.0351  0.7%   192 0.0002  0.00 ADMIN PREPARE
#   20 0x44EBC9974E0FE0B553B97C7B0FEFCE3D   0.0336  0.7%  1792 0.0000  0.00 INSERT time_zone_name
# MISC 0xMISC                               0.3458  7.2%  4973 0.0001   0.0 <61 ITEMS>
```

PROD
```
+-------+-----+-----+-----+-----+-----+--------+---------------------------------------------------------+-------+-------+--------+-------+-------+-------+-------+--------+-----------+------------+--------------+------------+
| COUNT | 1XX | 2XX | 3XX | 4XX | 5XX | METHOD |                           URI                           |  MIN  |  MAX  |  SUM   |  AVG  |  P90  |  P95  |  P99  | STDDEV | MIN(BODY) | MAX(BODY)  |  SUM(BODY)   | AVG(BODY)  |
+-------+-----+-----+-----+-----+-----+--------+---------------------------------------------------------+-------+-------+--------+-------+-------+-------+-------+--------+-----------+------------+--------------+------------+
| 64    | 0   | 63  | 0   | 1   | 0   | GET    | /api/tow_truck/nearest                                  | 0.001 | 2.426 | 19.511 | 0.305 | 0.873 | 0.985 | 2.426 | 0.517  | 49.000    | 115.000    | 7117.000     | 111.203    |
| 5     | 0   | 5   | 0   | 0   | 0   | GET    | /api/tow_truck/list                                     | 0.005 | 0.473 | 0.892  | 0.178 | 0.473 | 0.473 | 0.473 | 0.211  | 870.000   | 184496.000 | 188512.000   | 37702.400  |
| 4     | 0   | 2   | 0   | 2   | 0   | POST   | /api/register                                           | 0.000 | 0.245 | 0.395  | 0.099 | 0.245 | 0.245 | 0.245 | 0.104  | 25.000    | 166.000    | 415.000      | 103.750    |
| 73    | 0   | 69  | 0   | 4   | 0   | POST   | /api/login                                              | 0.027 | 0.095 | 5.112  | 0.070 | 0.080 | 0.085 | 0.095 | 0.011  | 26.000    | 166.000    | 10162.000    | 139.205    |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /orders                                                 | 0.014 | 2.239 | 4.330  | 0.067 | 0.029 | 0.036 | 2.239 | 0.289  | 1157.000  | 1279.000   | 82235.000    | 1265.154   |
| 68    | 0   | 58  | 0   | 10  | 0   | POST   | /api/order/[0-9]*                                       | 0.011 | 0.107 | 4.208  | 0.062 | 0.080 | 0.086 | 0.107 | 0.024  | 0.000     | 72.000     | 341.000      | 5.015      |
| 138   | 0   | 138 | 0   | 0   | 0   | GET    | /api/order/[0-9]*                                       | 0.001 | 2.229 | 4.346  | 0.031 | 0.011 | 0.015 | 0.802 | 0.204  | 313.000   | 7304.000   | 255001.000   | 1847.833   |
| 3     | 0   | 3   | 0   | 0   | 0   | PUT    | /api/map/update_edge                                    | 0.022 | 0.030 | 0.080  | 0.027 | 0.030 | 0.030 | 0.030 | 0.003  | 0.000     | 0.000      | 0.000        | 0.000      |
| 9     | 0   | 9   | 0   | 0   | 0   | POST   | /api/tow_truck/location                                 | 0.022 | 0.039 | 0.236  | 0.026 | 0.039 | 0.039 | 0.039 | 0.005  | 0.000     | 0.000      | 0.000        | 0.000      |
| 55    | 0   | 55  | 0   | 0   | 0   | POST   | /api/logout                                             | 0.020 | 0.036 | 1.292  | 0.023 | 0.030 | 0.032 | 0.036 | 0.004  | 0.000     | 0.000      | 0.000        | 0.000      |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/fd9d1056-90960e0a7e77703c.js       | 0.006 | 0.028 | 0.692  | 0.011 | 0.016 | 0.018 | 0.028 | 0.004  | 53786.000 | 53834.000  | 3498792.000  | 53827.569  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/51-0e89e4d746fa7a66.js             | 0.004 | 0.025 | 0.602  | 0.009 | 0.014 | 0.017 | 0.025 | 0.004  | 30099.000 | 30114.000  | 1957231.000  | 30111.246  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/825-b807d515c67f93a3.js            | 0.003 | 0.025 | 0.590  | 0.009 | 0.013 | 0.015 | 0.025 | 0.004  | 25247.000 | 25263.000  | 1641933.000  | 25260.508  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/23-ff14220b7d7270f6.js             | 0.004 | 0.025 | 0.541  | 0.008 | 0.012 | 0.014 | 0.025 | 0.003  | 31633.000 | 31672.000  | 2058420.000  | 31668.000  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/837-5a332c2cf6add18f.js            | 0.005 | 0.024 | 0.517  | 0.008 | 0.012 | 0.014 | 0.024 | 0.003  | 19911.000 | 19919.000  | 1294609.000  | 19917.062  |
| 195   | 0   | 195 | 0   | 0   | 0   | GET    | /orders/[0-9]*                                          | 0.001 | 0.501 | 1.340  | 0.007 | 0.011 | 0.012 | 0.028 | 0.036  | 165.000   | 1038.000   | 87825.000    | 450.385    |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/login/page-05ce8bd2d4d16bb9.js | 0.001 | 0.022 | 0.334  | 0.005 | 0.008 | 0.010 | 0.022 | 0.004  | 1501.000  | 1501.000   | 97565.000    | 1501.000   |
| 120   | 0   | 120 | 0   | 0   | 0   | GET    | /                                                       | 0.002 | 0.107 | 0.550  | 0.005 | 0.005 | 0.006 | 0.010 | 0.009  | 1200.000  | 1812.000   | 177660.000   | 1480.500   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/810-3db617b59f1d64ce.js            | 0.002 | 0.008 | 0.254  | 0.004 | 0.005 | 0.006 | 0.008 | 0.001  | 17776.000 | 17799.000  | 1156790.000  | 17796.769  |
| 65    | 0   | 65  | 0   | 0   | 0   | POST   | /session                                                | 0.002 | 0.018 | 0.202  | 0.003 | 0.004 | 0.004 | 0.018 | 0.002  | 48.000    | 48.000     | 3120.000     | 48.000     |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/layout-a447854c3bff4fcd.js     | 0.001 | 0.016 | 0.196  | 0.003 | 0.006 | 0.008 | 0.016 | 0.003  | 1054.000  | 1054.000   | 68510.000    | 1054.000   |
| 120   | 0   | 120 | 0   | 0   | 0   | GET    | /login                                                  | 0.001 | 0.078 | 0.357  | 0.003 | 0.003 | 0.004 | 0.005 | 0.007  | 1262.000  | 1877.000   | 191415.000   | 1595.125   |
| 642   | 0   | 641 | 0   | 1   | 0   | GET    | /api/user_image/*                                       | 0.001 | 0.099 | 1.792  | 0.003 | 0.004 | 0.004 | 0.014 | 0.009  | 23.000    | 164943.000 | 96706548.000 | 150633.252 |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/main-app-aad39d0b947a2963.js       | 0.001 | 0.014 | 0.180  | 0.003 | 0.005 | 0.006 | 0.014 | 0.002  | 460.000   | 460.000    | 29900.000    | 460.000    |
| 55    | 0   | 55  | 0   | 0   | 0   | DELETE | /session                                                | 0.001 | 0.005 | 0.141  | 0.003 | 0.003 | 0.004 | 0.005 | 0.001  | 51.000    | 51.000     | 2805.000     | 51.000     |
| 55    | 0   | 55  | 0   | 0   | 0   | GET    | /session                                                | 0.001 | 0.006 | 0.134  | 0.002 | 0.004 | 0.004 | 0.006 | 0.001  | 156.000   | 158.000    | 8604.000     | 156.436    |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/765-53bf182bd94b7b47.js            | 0.001 | 0.005 | 0.158  | 0.002 | 0.003 | 0.004 | 0.005 | 0.001  | 3535.000  | 3535.000   | 229775.000   | 3535.000   |
| 3     | 0   | 3   | 0   | 0   | 0   | GET    | /api/tow_truck/1                                        | 0.002 | 0.002 | 0.006  | 0.002 | 0.002 | 0.002 | 0.002 | 0.000  | 102.000   | 102.000    | 306.000      | 102.000    |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/webpack-137ac530a47d8278.js        | 0.001 | 0.012 | 0.125  | 0.002 | 0.003 | 0.005 | 0.012 | 0.002  | 1757.000  | 1757.000   | 114205.000   | 1757.000   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/page-8264df3e0d0b83d9.js       | 0.001 | 0.005 | 0.106  | 0.002 | 0.002 | 0.003 | 0.005 | 0.001  | 1292.000  | 1292.000   | 83980.000    | 1292.000   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/error-20d09d53a3e47e92.js      | 0.001 | 0.011 | 0.100  | 0.002 | 0.003 | 0.004 | 0.011 | 0.002  | 599.000   | 599.000    | 38935.000    | 599.000    |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/css/7c24bb46fac18203.css                  | 0.001 | 0.011 | 0.095  | 0.001 | 0.002 | 0.002 | 0.011 | 0.001  | 1094.000  | 1094.000   | 71110.000    | 1094.000   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/media/c9a5bc6a7c948fb0-s.p.woff2          | 0.001 | 0.005 | 0.080  | 0.001 | 0.002 | 0.003 | 0.005 | 0.001  | 46552.000 | 46552.000  | 3025880.000  | 46552.000  |
| 1     | 0   | 0   | 0   | 1   | 0   | GET    | /api/tow_truck/100000000                                | 0.001 | 0.001 | 0.001  | 0.001 | 0.001 | 0.001 | 0.001 | 0.000  | 0.000     | 0.000      | 0.000        | 0.000      |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/css/53792c77bc0423ee.css                  | 0.000 | 0.004 | 0.057  | 0.001 | 0.002 | 0.003 | 0.004 | 0.001  | 932.000   | 932.000    | 60580.000    | 932.000    |
+-------+-----+-----+-----+-----+-----+--------+---------------------------------------------------------+-------+-------+--------+-------+-------+-------+-------+--------+-----------+------------+--------------+------------+
```

```
# 470ms user time, 40ms system time, 36.45M rss, 392.01G vsz
# Current date: Sat Jul 27 15:28:22 2024
# Hostname: MacBook.local
# Files: slow.log
# Overall: 9.69k total, 84 unique, 6.49 QPS, 0.00x concurrency ___________
# Time range: 2024-07-26T18:06:23 to 2024-07-26T18:31:15
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time             2s     1us   467ms   250us   366us     7ms    22us
# Lock time            2ms       0   242us       0     1us     3us       0
# Rows sent          2.20k       0   1.58k    0.23       0   15.97       0
# Rows examine       5.06M       0   2.49M  547.26       0  34.24k       0
# Query size         4.56M       6   7.63k  493.64   3.52k   1.15k   88.31

# Profile
# Rank Query ID                            Response time Calls R/Call V/M
# ==== =================================== ============= ===== ====== ====
#    1 0xA361BBE6FFE611739E98EE96EB35491C   0.4674 19.3%     1 0.4674  0.00 SELECT tow_trucks users locations
#    2 0x7DFA2D5D9DBC803F79DB97773EC5447B   0.4250 17.5%  1696 0.0003  0.00 INSERT time_zone_transition
#    3 0x77DFA104A9A4D9D12635A7A0CBE1309A   0.3049 12.6%     1 0.3049  0.00 LOAD DATA users
#    4 0x135A2BFECAE321BE61BF48B520717C62   0.2589 10.7%     1 0.2589  0.00 SELECT tow_trucks users locations
#    5 0x422658A0BB67F143CA920D09BAB4918B   0.2504 10.3%     1 0.2504  0.00 LOAD DATA edges
#    6 0xB16EDE898E3C0ED14B8EF7512C77E37E   0.0935  3.9%     1 0.0935  0.00 LOAD DATA nodes
#    7 0x93B0490C6027E6D67E3D4DA357148667   0.0866  3.6%  1792 0.0000  0.00 INSERT time_zone_transition_type
#    8 0x44EBC9974E0FE0B553B97C7B0FEFCE3D   0.0492  2.0%  1792 0.0000  0.00 INSERT time_zone_name
#    9 0x87EE275335DA5BFC58C99B420A728D10   0.0444  1.8%    36 0.0012  0.01 SELECT tow_trucks users locations
#   10 0xAA83D87B5B11FC07C50163FB3A1C4E9C   0.0439  1.8%  1792 0.0000  0.00 INSERT time_zone
#   11 0x9D7DF3D0EC60655E834DE3E6172EBF47   0.0400  1.6%     1 0.0400  0.00 SELECT users
#   12 0xE5121492B943117E153CE283A7A0BC58   0.0379  1.6%     9 0.0042  0.01 INSERT locations
#   13 0x82B9AFEF42F3A4161BF7A5093007E638   0.0249  1.0%     1 0.0249  0.00 LOAD DATA orders
#   14 0x751417D45B8E80EE5CBA2034458B5BC9   0.0222  0.9%     1 0.0222  0.00 SHOW DATABASES
#   15 0x908FF3EE414069FBDFE9FF90701E227F   0.0193  0.8%     5 0.0039  0.00 SELECT tow_trucks users locations
#   16 0x98E1098203EF07827B5A8A396BEE8F90   0.0191  0.8%  1792 0.0000  0.00 SET
#   17 0xDA556F9115773A1A99AA0165670CE848   0.0189  0.8%    32 0.0006  0.00 ADMIN PREPARE
#   18 0xE633E2563F1A93ED51507EE5D969E439   0.0118  0.5%     1 0.0118  0.00 CREATE TABLE orders
#   19 0xE8390778DC20D4CC04FE01C5B31FD305   0.0105  0.4%   330 0.0000  0.00 ADMIN PING
#   20 0x01C9AF0536C9EBFF3AD4993FCF3B8322   0.0086  0.4%     1 0.0086  0.00 CREATE TABLE completed_orders
# MISC 0xMISC                               0.1895  7.8%   404 0.0005   0.0 <64 ITEMS>
```
