### PR TITLE
Stop using locations table

### DIFF
--- a/webapp/mysql/init/init.sql
+++ b/webapp/mysql/init/init.sql
@@ -160,5 +160,22 @@ IGNORE 1 ROWS
 -- sessions テーブルにテスト用のデータを追加
 INSERT INTO sessions (user_id, session_token) VALUES (100001, "GclZwGGYuogTIbhixe6D3nC6JIMkFH");
 
--- INDEX
+-- TUNING
+
+-- Add index to users table
 CREATE INDEX idx_username ON users(username);
+
+-- Move tow_truck's current location to tow_trucks table
+ALTER TABLE tow_trucks ADD COLUMN node_id INT;
+
+UPDATE tow_trucks tt
+JOIN (
+    SELECT tow_truck_id, node_id
+    FROM locations
+    WHERE (tow_truck_id, timestamp) IN (
+        SELECT tow_truck_id, MAX(timestamp)
+        FROM locations
+        GROUP BY tow_truck_id
+    )
+) l ON tt.id = l.tow_truck_id
+SET tt.node_id = l.node_id;


### PR DESCRIPTION
local
```
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+---------+-------+-------+--------+--------+--------+-------------+-------------+--------------+-------------+
| COUNT | 1XX | 2XX | 3XX | 4XX | 5XX | METHOD |                              URI                               |  MIN  |  MAX   |   SUM   |  AVG  |  P90  |  P95   |  P99   | STDDEV |  MIN(BODY)  |  MAX(BODY)  |  SUM(BODY)   |  AVG(BODY)  |
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+---------+-------+-------+--------+--------+--------+-------------+-------------+--------------+-------------+
| 57    | 57  | 0   | 0   | 0   | 0   | GET    | /_next/webpack-hmr                                             | 0.482 | 37.547 | 349.090 | 6.124 | 7.657 | 35.912 | 37.547 | 9.654  | 156.000     | 5304.000    | 44589.000    | 782.263     |
| 40    | 0   | 36  | 0   | 4   | 0   | POST   | /api/login                                                     | 0.361 | 1.044  | 15.303  | 0.383 | 0.437 | 0.497  | 1.044  | 0.160  | 26.000      | 167.000     | 5363.000     | 134.075     |
| 4     | 0   | 2   | 0   | 2   | 0   | POST   | /api/register                                                  | 0.000 | 0.549  | 0.910   | 0.228 | 0.549 | 0.549  | 0.549  | 0.237  | 25.000      | 167.000     | 418.000      | 104.500     |
| 36    | 0   | 35  | 0   | 1   | 0   | GET    | /api/tow_truck/nearest                                         | 0.007 | 1.570  | 7.646   | 0.212 | 0.822 | 1.482  | 1.570  | 0.393  | 49.000      | 115.000     | 3962.000     | 110.056     |
| 59    | 0   | 59  | 0   | 0   | 0   | GET    | /_next/static/chunks/main-app.js                               | 0.106 | 0.581  | 10.654  | 0.181 | 0.282 | 0.398  | 0.581  | 0.095  | 1343274.000 | 1343329.000 | 79255582.000 | 1343314.949 |
| 59    | 0   | 59  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/login/page.js                         | 0.051 | 0.429  | 5.719   | 0.097 | 0.141 | 0.265  | 0.429  | 0.074  | 886330.000  | 886378.000  | 52295542.000 | 886365.119  |
| 59    | 0   | 59  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/page.js                               | 0.029 | 0.168  | 3.071   | 0.052 | 0.076 | 0.115  | 0.168  | 0.029  | 490371.000  | 490418.000  | 28933893.000 | 490404.966  |
| 192   | 0   | 192 | 0   | 0   | 0   | GET    | /orders/[0-9]*                                                 | 0.001 | 0.753  | 9.675   | 0.050 | 0.105 | 0.127  | 0.417  | 0.075  | 123.000     | 1111320.000 | 71203937.000 | 370853.839  |
| 64    | 0   | 64  | 0   | 0   | 0   | GET    | /orders                                                        | 0.013 | 0.738  | 2.442   | 0.038 | 0.044 | 0.054  | 0.738  | 0.089  | 104.000     | 1357.000    | 46255.000    | 722.734     |
| 86    | 0   | 86  | 0   | 0   | 0   | GET    | /login                                                         | 0.006 | 1.690  | 3.127   | 0.036 | 0.030 | 0.037  | 1.690  | 0.180  | 103.000     | 2435.000    | 97610.000    | 1135.000    |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.681e8a45eacbb3cc.hot-update.js   | 0.034 | 0.034  | 0.034   | 0.034 | 0.034 | 0.034  | 0.034  | 0.000  | 858.000     | 858.000     | 858.000      | 858.000     |
| 91    | 0   | 91  | 0   | 0   | 0   | GET    | /                                                              | 0.011 | 0.412  | 3.027   | 0.033 | 0.035 | 0.080  | 0.412  | 0.056  | 88.000      | 2382.000    | 82164.000    | 902.901     |
| 59    | 0   | 59  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/layout.js                             | 0.015 | 0.145  | 1.851   | 0.031 | 0.046 | 0.053  | 0.145  | 0.023  | 164118.000  | 164157.000  | 9684164.000  | 164138.373  |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.92c248517bb20d80.hot-update.js   | 0.028 | 0.028  | 0.028   | 0.028 | 0.028 | 0.028  | 0.028  | 0.000  | 858.000     | 858.000     | 858.000      | 858.000     |
| 40    | 0   | 30  | 0   | 10  | 0   | POST   | /api/order/[0-9]*                                              | 0.003 | 0.253  | 1.061   | 0.027 | 0.034 | 0.172  | 0.253  | 0.055  | 0.000       | 72.000      | 341.000      | 8.525       |
| 32    | 0   | 32  | 0   | 0   | 0   | POST   | /session                                                       | 0.006 | 0.299  | 0.659   | 0.021 | 0.028 | 0.054  | 0.299  | 0.051  | 48.000      | 48.000      | 1536.000     | 48.000      |
| 54    | 0   | 54  | 0   | 0   | 0   | GET    | /session                                                       | 0.006 | 0.040  | 0.761   | 0.014 | 0.024 | 0.027  | 0.040  | 0.007  | 156.000     | 157.000     | 8442.000     | 156.333     |
| 59    | 0   | 59  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/error.js                              | 0.005 | 0.056  | 0.764   | 0.013 | 0.021 | 0.029  | 0.056  | 0.009  | 37328.000   | 37367.000   | 2203917.000  | 37354.525   |
| 312   | 0   | 311 | 0   | 1   | 0   | GET    | /api/user_image/*                                              | 0.001 | 0.183  | 3.658   | 0.012 | 0.015 | 0.029  | 0.151  | 0.025  | 23.000      | 164943.000  | 46529247.000 | 149132.202  |
| 59    | 0   | 59  | 0   | 0   | 0   | GET    | /_next/static/chunks/app-pages-internals.js                    | 0.004 | 0.051  | 0.635   | 0.011 | 0.019 | 0.031  | 0.051  | 0.008  | 31285.000   | 31324.000   | 1847544.000  | 31314.305   |
| 27    | 0   | 27  | 0   | 0   | 0   | DELETE | /session                                                       | 0.006 | 0.022  | 0.288   | 0.011 | 0.015 | 0.017  | 0.022  | 0.004  | 51.000      | 51.000      | 1377.000     | 51.000      |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/3f295d89aa78ef9a.webpack.hot-update.json | 0.010 | 0.010  | 0.010   | 0.010 | 0.010 | 0.010  | 0.010  | 0.000  | 31.000      | 31.000      | 31.000       | 31.000      |
| 72    | 0   | 72  | 0   | 0   | 0   | GET    | /api/order/[0-9]*                                              | 0.001 | 0.389  | 0.641   | 0.009 | 0.005 | 0.008  | 0.389  | 0.045  | 313.000     | 7304.000    | 137714.000   | 1912.694    |
| 27    | 0   | 27  | 0   | 0   | 0   | POST   | /api/logout                                                    | 0.003 | 0.016  | 0.184   | 0.007 | 0.012 | 0.012  | 0.016  | 0.003  | 0.000       | 0.000       | 0.000        | 0.000       |
| 5     | 0   | 5   | 0   | 0   | 0   | GET    | /api/tow_truck/list                                            | 0.001 | 0.026  | 0.031   | 0.006 | 0.026 | 0.026  | 0.026  | 0.010  | 870.000     | 184496.000  | 188512.000   | 37702.400   |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.3f295d89aa78ef9a.hot-update.js   | 0.006 | 0.006  | 0.006   | 0.006 | 0.006 | 0.006  | 0.006  | 0.000  | 858.000     | 858.000     | 858.000      | 858.000     |
| 59    | 0   | 59  | 0   | 0   | 0   | GET    | /_next/static/chunks/webpack.js                                | 0.002 | 0.014  | 0.350   | 0.006 | 0.012 | 0.013  | 0.014  | 0.003  | 10538.000   | 10552.000   | 622062.000   | 10543.424   |
| 59    | 0   | 59  | 0   | 0   | 0   | GET    | /_next/static/css/app/layout.css                               | 0.001 | 0.014  | 0.281   | 0.005 | 0.010 | 0.012  | 0.014  | 0.003  | 1560.000    | 1560.000    | 92040.000    | 1560.000    |
| 32    | 0   | 32  | 0   | 0   | 0   | GET    | /_next/static/media/c9a5bc6a7c948fb0-s.p.woff2                 | 0.001 | 0.009  | 0.117   | 0.004 | 0.007 | 0.009  | 0.009  | 0.002  | 46552.000   | 46552.000   | 1489664.000  | 46552.000   |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/681e8a45eacbb3cc.webpack.hot-update.json | 0.003 | 0.003  | 0.003   | 0.003 | 0.003 | 0.003  | 0.003  | 0.000  | 31.000      | 31.000      | 31.000       | 31.000      |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/92c248517bb20d80.webpack.hot-update.json | 0.003 | 0.003  | 0.003   | 0.003 | 0.003 | 0.003  | 0.003  | 0.000  | 31.000      | 31.000      | 31.000       | 31.000      |
| 3     | 0   | 3   | 0   | 0   | 0   | PUT    | /api/map/update_edge                                           | 0.001 | 0.002  | 0.005   | 0.002 | 0.002 | 0.002  | 0.002  | 0.000  | 0.000       | 0.000       | 0.000        | 0.000       |
| 9     | 0   | 9   | 0   | 0   | 0   | POST   | /api/tow_truck/location                                        | 0.001 | 0.003  | 0.013   | 0.001 | 0.003 | 0.003  | 0.003  | 0.001  | 0.000       | 0.000       | 0.000        | 0.000       |
| 1     | 0   | 0   | 0   | 1   | 0   | GET    | /api/tow_truck/100000000                                       | 0.001 | 0.001  | 0.001   | 0.001 | 0.001 | 0.001  | 0.001  | 0.000  | 0.000       | 0.000       | 0.000        | 0.000       |
| 3     | 0   | 3   | 0   | 0   | 0   | GET    | /api/tow_truck/1                                               | 0.001 | 0.001  | 0.003   | 0.001 | 0.001 | 0.001  | 0.001  | 0.000  | 102.000     | 102.000     | 306.000      | 102.000     |
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+---------+-------+-------+--------+--------+--------+-------------+-------------+--------------+-------------+
```

```
# 560ms user time, 30ms system time, 35.25M rss, 391.43G vsz
# Current date: Sat Jul 27 20:07:51 2024
# Hostname: MacBook.local
# Files: slow.log
# Overall: 11.61k total, 82 unique, 81.20 QPS, 0.02x concurrency _________
# Time range: 2024-07-27T11:04:16 to 2024-07-27T11:06:39
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time             3s     1us   275ms   248us   366us     4ms    18us
# Lock time            4ms       0   202us       0     1us     2us       0
# Rows sent        390.77k       0  48.83k   34.46    0.99   1.01k       0
# Rows examine       1.34M       0  60.77k  120.89    0.99   1.59k       0
# Query size         4.69M       6   7.63k  423.34   2.89k   1.06k   76.28

# Profile
# Rank Query ID                            Response time Calls R/Call V/M 
# ==== =================================== ============= ===== ====== ====
#    1 0xF3D90F2F70D70848EA75F9D3300BF7BD   0.4882 16.9%    35 0.0139  0.05 SELECT edges nodes
#    2 0x8A3E4B6435519E43C2B8B8E135E99668   0.3891 13.5%    34 0.0114  0.13 INSERT completed_orders
#    3 0x7DFA2D5D9DBC803F79DB97773EC5447B   0.3026 10.5%  1696 0.0002  0.00 INSERT time_zone_transition
#    4 0x77DFA104A9A4D9D12635A7A0CBE1309A   0.2749  9.5%     1 0.2749  0.00 LOAD DATA users
#    5 0x422658A0BB67F143CA920D09BAB4918B   0.2151  7.5%     1 0.2151  0.00 LOAD DATA edges
#    6 0x6B1CA44888341BCBADC7E7D6C44D41B5   0.1426  4.9%    39 0.0037  0.00 INSERT sessions
#    7 0x04BBD25509FE01B133EB50DCE5E01990   0.1406  4.9%    27 0.0052  0.00 DELETE sessions
#    8 0xD54A281FB93595B0456A5C68CBA58B59   0.1150  4.0%    35 0.0033  0.00 SELECT nodes
#    9 0x45DCEA13C4252CE30BAABA0BACD76CBC   0.1000  3.5%    28 0.0036  0.00 UPDATE orders
#   10 0xC723F48BCC895E734B69049287D2F63C   0.0857  3.0%    28 0.0031  0.00 UPDATE tow_trucks
#   11 0x93B0490C6027E6D67E3D4DA357148667   0.0616  2.1%  1792 0.0000  0.00 INSERT time_zone_transition_type
#   12 0xB16EDE898E3C0ED14B8EF7512C77E37E   0.0564  2.0%     1 0.0564  0.00 LOAD DATA nodes
#   13 0xE8390778DC20D4CC04FE01C5B31FD305   0.0479  1.7%  1429 0.0000  0.00 ADMIN PING
#   14 0x6F4DCC2FA6E75F6BE278DF1C250A7022   0.0415  1.4%    34 0.0012  0.00 SELECT orders nodes users dispatchers users tow_trucks users
#   15 0xDA556F9115773A1A99AA0165670CE848   0.0370  1.3%   192 0.0002  0.00 ADMIN PREPARE
#   16 0xA0E74157814D3B028858FEF1E6A316B6   0.0364  1.3%   312 0.0001  0.00 SELECT users
#   17 0x831C55E7C29B6A369E3248A1844130A2   0.0333  1.2%    37 0.0009  0.00 SELECT tow_trucks users
#   18 0x44EBC9974E0FE0B553B97C7B0FEFCE3D   0.0313  1.1%  1792 0.0000  0.00 INSERT time_zone_name
#   19 0xAA83D87B5B11FC07C50163FB3A1C4E9C   0.0272  0.9%  1792 0.0000  0.00 INSERT time_zone
#   20 0xD97008D27DB00DF57AF34721795BEDE0   0.0265  0.9%   169 0.0002  0.00 SELECT sessions
# MISC 0xMISC                               0.2301  8.0%  2138 0.0001   0.0 <62 ITEMS>
```

prod
```
```

```
```