### PR TITLE
Use migration file

### DIFF
--- a/webapp/mysql/init/init.sql
+++ b/webapp/mysql/init/init.sql
@@ -159,23 +159,3 @@ IGNORE 1 ROWS
 
 -- sessions テーブルにテスト用のデータを追加
 INSERT INTO sessions (user_id, session_token) VALUES (100001, "GclZwGGYuogTIbhixe6D3nC6JIMkFH");
-
--- TUNING
-
--- Add index to users table
-CREATE INDEX idx_username ON users(username);
-
--- Move tow_truck's current location to tow_trucks table
-ALTER TABLE tow_trucks ADD COLUMN node_id INT;
-
-UPDATE tow_trucks tt
-JOIN (
-    SELECT tow_truck_id, node_id
-    FROM locations
-    WHERE (tow_truck_id, timestamp) IN (
-        SELECT tow_truck_id, MAX(timestamp)
-        FROM locations
-        GROUP BY tow_truck_id
-    )
-) l ON tt.id = l.tow_truck_id
-SET tt.node_id = l.node_id;

--- a/webapp/mysql/migration/0_sample.sql
+++ b/webapp/mysql/migration/0_sample.sql
@@ -1,1 +1,19 @@
 -- このファイルに記述されたSQLコマンドが、マイグレーション時に実行されます。
+
+-- Add index to users table
+CREATE INDEX idx_username ON users(username);
+
+-- Move tow_truck's current location to tow_trucks table
+ALTER TABLE tow_trucks ADD COLUMN node_id INT;
+
+UPDATE tow_trucks tt
+JOIN (
+    SELECT tow_truck_id, node_id
+    FROM locations
+    WHERE (tow_truck_id, timestamp) IN (
+        SELECT tow_truck_id, MAX(timestamp)
+        FROM locations
+        GROUP BY tow_truck_id
+    )
+) l ON tt.id = l.tow_truck_id
+SET tt.node_id = l.node_id;


### PR DESCRIPTION
local
```
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+----------+-------+-------+--------+--------+--------+-------------+-------------+---------------+-------------+
| COUNT | 1XX | 2XX | 3XX | 4XX | 5XX | METHOD |                              URI                               |  MIN  |  MAX   |   SUM    |  AVG  |  P90  |  P95   |  P99   | STDDEV |  MIN(BODY)  |  MAX(BODY)  |   SUM(BODY)   |  AVG(BODY)  |
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+----------+-------+-------+--------+--------+--------+-------------+-------------+---------------+-------------+
| 169   | 169 | 0   | 0   | 0   | 0   | GET    | /_next/webpack-hmr                                             | 0.482 | 38.259 | 1047.953 | 6.201 | 7.794 | 35.912 | 38.124 | 9.741  | 156.000     | 5304.000    | 127909.000    | 756.858     |
| 117   | 0   | 105 | 0   | 12  | 0   | POST   | /api/login                                                     | 0.001 | 1.088  | 46.004   | 0.393 | 0.497 | 0.727  | 1.044  | 0.169  | 26.000      | 167.000     | 15650.000     | 133.761     |
| 12    | 0   | 6   | 0   | 6   | 0   | POST   | /api/register                                                  | 0.001 | 0.753  | 3.235    | 0.270 | 0.649 | 0.753  | 0.753  | 0.287  | 25.000      | 167.000     | 1252.000      | 104.333     |
| 105   | 0   | 102 | 0   | 3   | 0   | GET    | /api/tow_truck/nearest                                         | 0.007 | 1.789  | 21.473   | 0.205 | 0.793 | 0.927  | 1.570  | 0.367  | 49.000      | 115.000     | 11546.000     | 109.962     |
| 171   | 0   | 171 | 0   | 0   | 0   | GET    | /_next/static/chunks/main-app.js                               | 0.106 | 0.581  | 30.230   | 0.177 | 0.284 | 0.343  | 0.540  | 0.079  | 1343274.000 | 1343337.000 | 229707027.000 | 1343315.947 |
| 171   | 0   | 171 | 0   | 0   | 0   | GET    | /_next/static/chunks/app/login/page.js                         | 0.051 | 0.429  | 16.327   | 0.095 | 0.166 | 0.199  | 0.420  | 0.059  | 886330.000  | 886378.000  | 151568499.000 | 886365.491  |
| 171   | 0   | 171 | 0   | 0   | 0   | GET    | /_next/static/chunks/app/page.js                               | 0.029 | 0.169  | 8.772    | 0.051 | 0.076 | 0.103  | 0.168  | 0.025  | 490371.000  | 490426.000  | 83859348.000  | 490405.544  |
| 558   | 0   | 558 | 0   | 0   | 0   | GET    | /orders/[0-9]*                                                 | 0.001 | 0.753  | 28.331   | 0.051 | 0.114 | 0.138  | 0.327  | 0.066  | 123.000     | 1111320.000 | 206936546.000 | 370854.025  |
| 117   | 0   | 87  | 0   | 30  | 0   | POST   | /api/order/[0-9]*                                              | 0.001 | 0.574  | 4.300    | 0.037 | 0.110 | 0.253  | 0.450  | 0.090  | 0.000       | 72.000      | 1023.000      | 8.744       |
| 186   | 0   | 186 | 0   | 0   | 0   | GET    | /orders                                                        | 0.012 | 0.738  | 6.376    | 0.034 | 0.053 | 0.066  | 0.251  | 0.057  | 104.000     | 1357.000    | 134428.000    | 722.731     |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.681e8a45eacbb3cc.hot-update.js   | 0.034 | 0.034  | 0.034    | 0.034 | 0.034 | 0.034  | 0.034  | 0.000  | 858.000     | 858.000     | 858.000       | 858.000     |
| 171   | 0   | 171 | 0   | 0   | 0   | GET    | /_next/static/chunks/app/layout.js                             | 0.014 | 0.145  | 5.165    | 0.030 | 0.047 | 0.063  | 0.144  | 0.018  | 164102.000  | 164157.000  | 28067565.000  | 164137.807  |
| 264   | 0   | 264 | 0   | 0   | 0   | GET    | /                                                              | 0.009 | 0.412  | 7.432    | 0.028 | 0.040 | 0.060  | 0.264  | 0.036  | 88.000      | 2383.000    | 237685.000    | 900.322     |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.92c248517bb20d80.hot-update.js   | 0.028 | 0.028  | 0.028    | 0.028 | 0.028 | 0.028  | 0.028  | 0.000  | 858.000     | 858.000     | 858.000       | 858.000     |
| 78    | 0   | 78  | 0   | 0   | 0   | POST   | /api/logout                                                    | 0.002 | 0.583  | 2.112    | 0.027 | 0.016 | 0.185  | 0.583  | 0.091  | 0.000       | 0.000       | 0.000         | 0.000       |
| 249   | 0   | 249 | 0   | 0   | 0   | GET    | /login                                                         | 0.005 | 1.690  | 5.958    | 0.024 | 0.030 | 0.039  | 0.090  | 0.107  | 103.000     | 2435.000    | 283331.000    | 1137.876    |
| 906   | 0   | 903 | 0   | 3   | 0   | GET    | /api/user_image/*                                              | 0.001 | 0.945  | 16.688   | 0.018 | 0.017 | 0.050  | 0.342  | 0.073  | 23.000      | 164943.000  | 135023478.000 | 149032.536  |
| 156   | 0   | 156 | 0   | 0   | 0   | GET    | /session                                                       | 0.006 | 0.075  | 2.611    | 0.017 | 0.030 | 0.040  | 0.069  | 0.011  | 156.000     | 157.000     | 24386.000     | 156.321     |
| 93    | 0   | 93  | 0   | 0   | 0   | POST   | /session                                                       | 0.006 | 0.299  | 1.439    | 0.015 | 0.024 | 0.029  | 0.299  | 0.031  | 48.000      | 48.000      | 4464.000      | 48.000      |
| 210   | 0   | 210 | 0   | 0   | 0   | GET    | /api/order/[0-9]*                                              | 0.001 | 0.389  | 2.754    | 0.013 | 0.008 | 0.047  | 0.267  | 0.045  | 313.000     | 7304.000    | 402481.000    | 1916.576    |
| 171   | 0   | 171 | 0   | 0   | 0   | GET    | /_next/static/chunks/app/error.js                              | 0.005 | 0.056  | 2.186    | 0.013 | 0.022 | 0.028  | 0.050  | 0.007  | 37328.000   | 37367.000   | 6387584.000   | 37354.292   |
| 78    | 0   | 78  | 0   | 0   | 0   | DELETE | /session                                                       | 0.006 | 0.068  | 0.989    | 0.013 | 0.022 | 0.046  | 0.068  | 0.011  | 51.000      | 51.000      | 3978.000      | 51.000      |
| 171   | 0   | 171 | 0   | 0   | 0   | GET    | /_next/static/chunks/app-pages-internals.js                    | 0.004 | 0.051  | 1.835    | 0.011 | 0.019 | 0.027  | 0.039  | 0.007  | 31285.000   | 31324.000   | 5354638.000   | 31313.673   |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/3f295d89aa78ef9a.webpack.hot-update.json | 0.010 | 0.010  | 0.010    | 0.010 | 0.010 | 0.010  | 0.010  | 0.000  | 31.000      | 31.000      | 31.000        | 31.000      |
| 15    | 0   | 15  | 0   | 0   | 0   | GET    | /api/tow_truck/list                                            | 0.001 | 0.028  | 0.098    | 0.007 | 0.027 | 0.028  | 0.028  | 0.010  | 870.000     | 184496.000  | 565536.000    | 37702.400   |
| 171   | 0   | 171 | 0   | 0   | 0   | GET    | /_next/static/chunks/webpack.js                                | 0.002 | 0.028  | 1.027    | 0.006 | 0.012 | 0.013  | 0.022  | 0.004  | 10538.000   | 10552.000   | 1802955.000   | 10543.596   |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/webpack.3f295d89aa78ef9a.hot-update.js   | 0.006 | 0.006  | 0.006    | 0.006 | 0.006 | 0.006  | 0.006  | 0.000  | 858.000     | 858.000     | 858.000       | 858.000     |
| 171   | 0   | 171 | 0   | 0   | 0   | GET    | /_next/static/css/app/layout.css                               | 0.001 | 0.036  | 0.837    | 0.005 | 0.009 | 0.012  | 0.018  | 0.004  | 1560.000    | 1560.000    | 266760.000    | 1560.000    |
| 93    | 0   | 93  | 0   | 0   | 0   | GET    | /_next/static/media/c9a5bc6a7c948fb0-s.p.woff2                 | 0.001 | 0.013  | 0.335    | 0.004 | 0.007 | 0.009  | 0.013  | 0.002  | 46552.000   | 46552.000   | 4329336.000   | 46552.000   |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/681e8a45eacbb3cc.webpack.hot-update.json | 0.003 | 0.003  | 0.003    | 0.003 | 0.003 | 0.003  | 0.003  | 0.000  | 31.000      | 31.000      | 31.000        | 31.000      |
| 1     | 0   | 1   | 0   | 0   | 0   | GET    | /_next/static/webpack/92c248517bb20d80.webpack.hot-update.json | 0.003 | 0.003  | 0.003    | 0.003 | 0.003 | 0.003  | 0.003  | 0.000  | 31.000      | 31.000      | 31.000        | 31.000      |
| 27    | 0   | 27  | 0   | 0   | 0   | POST   | /api/tow_truck/location                                        | 0.001 | 0.003  | 0.045    | 0.002 | 0.002 | 0.003  | 0.003  | 0.001  | 0.000       | 0.000       | 0.000         | 0.000       |
| 9     | 0   | 9   | 0   | 0   | 0   | PUT    | /api/map/update_edge                                           | 0.001 | 0.002  | 0.014    | 0.002 | 0.002 | 0.002  | 0.002  | 0.000  | 0.000       | 0.000       | 0.000         | 0.000       |
| 9     | 0   | 9   | 0   | 0   | 0   | GET    | /api/tow_truck/1                                               | 0.001 | 0.001  | 0.007    | 0.001 | 0.001 | 0.001  | 0.001  | 0.000  | 102.000     | 102.000     | 918.000       | 102.000     |
| 3     | 0   | 0   | 0   | 3   | 0   | GET    | /api/tow_truck/100000000                                       | 0.000 | 0.001  | 0.002    | 0.001 | 0.001 | 0.001  | 0.001  | 0.000  | 0.000       | 0.000       | 0.000         | 0.000       |
+-------+-----+-----+-----+-----+-----+--------+----------------------------------------------------------------+-------+--------+----------+-------+-------+--------+--------+--------+-------------+-------------+---------------+-------------+
```

```
# 580ms user time, 30ms system time, 35.30M rss, 391.46G vsz
# Current date: Sat Jul 27 20:33:36 2024
# Hostname: MacBook.local
# Files: slow.log
# Overall: 11.62k total, 81 unique, 108.57 QPS, 0.04x concurrency ________
# Time range: 2024-07-27T11:29:59 to 2024-07-27T11:31:46
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time             5s     1us      1s   387us   384us    12ms    19us
# Lock time          117ms       0   109ms    10us     1us   975us       0
# Rows sent        379.56k       0  48.83k   33.46    0.99   1.01k       0
# Rows examine       3.79M       0   2.49M  341.95    0.99  22.59k       0
# Query size         4.69M       6   7.63k  422.91   2.89k   1.06k   72.65

# Profile
# Rank Query ID                            Response time Calls R/Call V/M 
# ==== =================================== ============= ===== ====== ====
#    1 0x031847BDCB4ADEF6F0635C123B7461D4   1.0072 22.4%     1 1.0072  0.00 UPDATE SELECT tow_trucks locations
#    2 0x8A3E4B6435519E43C2B8B8E135E99668   0.6440 14.3%    33 0.0195  0.29 INSERT completed_orders
#    3 0x422658A0BB67F143CA920D09BAB4918B   0.6300 14.0%     1 0.6300  0.00 LOAD DATA edges
#    4 0xF3D90F2F70D70848EA75F9D3300BF7BD   0.4791 10.6%    34 0.0141  0.06 SELECT edges nodes
#    5 0x7DFA2D5D9DBC803F79DB97773EC5447B   0.3166  7.0%  1696 0.0002  0.00 INSERT time_zone_transition
#    6 0x77DFA104A9A4D9D12635A7A0CBE1309A   0.3006  6.7%     1 0.3006  0.00 LOAD DATA users
#    7 0x6B1CA44888341BCBADC7E7D6C44D41B5   0.1217  2.7%    38 0.0032  0.00 INSERT sessions
#    8 0xD54A281FB93595B0456A5C68CBA58B59   0.1008  2.2%    34 0.0030  0.00 SELECT nodes
#    9 0x04BBD25509FE01B133EB50DCE5E01990   0.0974  2.2%    26 0.0037  0.00 DELETE sessions
#   10 0xB16EDE898E3C0ED14B8EF7512C77E37E   0.0775  1.7%     1 0.0775  0.00 LOAD DATA nodes
#   11 0x45DCEA13C4252CE30BAABA0BACD76CBC   0.0741  1.6%    27 0.0027  0.00 UPDATE orders
#   12 0x93B0490C6027E6D67E3D4DA357148667   0.0636  1.4%  1792 0.0000  0.00 INSERT time_zone_transition_type
#   13 0xE8390778DC20D4CC04FE01C5B31FD305   0.0465  1.0%  1456 0.0000  0.00 ADMIN PING
#   14 0x6F4DCC2FA6E75F6BE278DF1C250A7022   0.0432  1.0%    33 0.0013  0.00 SELECT orders nodes users dispatchers users tow_trucks users
#   15 0xC723F48BCC895E734B69049287D2F63C   0.0402  0.9%    27 0.0015  0.00 UPDATE tow_trucks
#   16 0xA0E74157814D3B028858FEF1E6A316B6   0.0402  0.9%   302 0.0001  0.00 SELECT users
#   17 0x82B9AFEF42F3A4161BF7A5093007E638   0.0360  0.8%     1 0.0360  0.00 LOAD DATA orders
#   18 0xDA556F9115773A1A99AA0165670CE848   0.0359  0.8%   205 0.0002  0.00 ADMIN PREPARE
#   19 0x44EBC9974E0FE0B553B97C7B0FEFCE3D   0.0324  0.7%  1792 0.0000  0.00 INSERT time_zone_name
#   20 0xD97008D27DB00DF57AF34721795BEDE0   0.0318  0.7%   165 0.0002  0.00 SELECT sessions
# MISC 0xMISC                               0.2852  6.3%  3952 0.0001   0.0 <61 ITEMS>
```

prod
```
+-------+-----+-----+-----+-----+-----+--------+---------------------------------------------------------+-------+-------+--------+-------+-------+-------+-------+--------+-----------+------------+--------------+------------+
| COUNT | 1XX | 2XX | 3XX | 4XX | 5XX | METHOD |                           URI                           |  MIN  |  MAX  |  SUM   |  AVG  |  P90  |  P95  |  P99  | STDDEV | MIN(BODY) | MAX(BODY)  |  SUM(BODY)   | AVG(BODY)  |
+-------+-----+-----+-----+-----+-----+--------+---------------------------------------------------------+-------+-------+--------+-------+-------+-------+-------+--------+-----------+------------+--------------+------------+
| 65    | 0   | 64  | 0   | 1   | 0   | GET    | /api/tow_truck/nearest                                  | 0.009 | 2.463 | 15.554 | 0.239 | 0.818 | 0.828 | 2.463 | 0.477  | 49.000    | 115.000    | 7230.000     | 111.231    |
| 69    | 0   | 58  | 0   | 11  | 0   | POST   | /api/order/[0-9]*                                       | 0.001 | 2.343 | 7.178  | 0.104 | 0.089 | 0.099 | 2.343 | 0.278  | 0.000     | 72.000     | 366.000      | 5.304      |
| 4     | 0   | 2   | 0   | 2   | 0   | POST   | /api/register                                           | 0.000 | 0.183 | 0.279  | 0.070 | 0.183 | 0.183 | 0.183 | 0.076  | 25.000    | 166.000    | 416.000      | 104.000    |
| 73    | 0   | 69  | 0   | 4   | 0   | POST   | /api/login                                              | 0.001 | 0.064 | 3.180  | 0.044 | 0.053 | 0.055 | 0.064 | 0.011  | 26.000    | 166.000    | 10163.000    | 139.219    |
| 55    | 0   | 55  | 0   | 0   | 0   | POST   | /api/logout                                             | 0.020 | 0.236 | 1.607  | 0.029 | 0.033 | 0.040 | 0.236 | 0.029  | 0.000     | 0.000      | 0.000        | 0.000      |
| 9     | 0   | 9   | 0   | 0   | 0   | POST   | /api/tow_truck/location                                 | 0.022 | 0.027 | 0.217  | 0.024 | 0.027 | 0.027 | 0.027 | 0.002  | 0.000     | 0.000      | 0.000        | 0.000      |
| 3     | 0   | 3   | 0   | 0   | 0   | PUT    | /api/map/update_edge                                    | 0.021 | 0.026 | 0.070  | 0.023 | 0.026 | 0.026 | 0.026 | 0.002  | 0.000     | 0.000      | 0.000        | 0.000      |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /orders                                                 | 0.008 | 0.144 | 1.007  | 0.015 | 0.016 | 0.029 | 0.144 | 0.021  | 1157.000  | 1279.000   | 82217.000    | 1264.877   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/fd9d1056-90960e0a7e77703c.js       | 0.005 | 0.030 | 0.651  | 0.010 | 0.012 | 0.019 | 0.030 | 0.004  | 53818.000 | 53834.000  | 3498926.000  | 53829.631  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/51-0e89e4d746fa7a66.js             | 0.003 | 0.027 | 0.548  | 0.008 | 0.013 | 0.016 | 0.027 | 0.004  | 30099.000 | 30114.000  | 1957282.000  | 30112.031  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/23-ff14220b7d7270f6.js             | 0.003 | 0.025 | 0.513  | 0.008 | 0.011 | 0.014 | 0.025 | 0.004  | 31657.000 | 31672.000  | 2058414.000  | 31667.908  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/825-b807d515c67f93a3.js            | 0.003 | 0.029 | 0.511  | 0.008 | 0.011 | 0.015 | 0.029 | 0.004  | 25224.000 | 25263.000  | 1641947.000  | 25260.723  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/837-5a332c2cf6add18f.js            | 0.003 | 0.025 | 0.466  | 0.007 | 0.010 | 0.012 | 0.025 | 0.003  | 19911.000 | 19919.000  | 1294590.000  | 19916.769  |
| 5     | 0   | 5   | 0   | 0   | 0   | GET    | /api/tow_truck/list                                     | 0.001 | 0.025 | 0.033  | 0.007 | 0.025 | 0.025 | 0.025 | 0.009  | 870.000   | 184496.000 | 188512.000   | 37702.400  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/login/page-05ce8bd2d4d16bb9.js | 0.001 | 0.019 | 0.293  | 0.005 | 0.007 | 0.012 | 0.019 | 0.003  | 1501.000  | 1501.000   | 97565.000    | 1501.000   |
| 121   | 0   | 120 | 1   | 0   | 0   | GET    | /                                                       | 0.002 | 0.109 | 0.537  | 0.004 | 0.005 | 0.006 | 0.008 | 0.010  | 16.000    | 1812.000   | 177676.000   | 1468.397   |
| 195   | 0   | 195 | 0   | 0   | 0   | GET    | /orders/[0-9]*                                          | 0.001 | 0.024 | 0.838  | 0.004 | 0.010 | 0.012 | 0.020 | 0.005  | 165.000   | 1038.000   | 87720.000    | 449.846    |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/810-3db617b59f1d64ce.js            | 0.002 | 0.009 | 0.242  | 0.004 | 0.005 | 0.005 | 0.009 | 0.001  | 17776.000 | 17799.000  | 1156853.000  | 17797.738  |
| 642   | 0   | 641 | 0   | 1   | 0   | GET    | /api/user_image/*                                       | 0.001 | 0.127 | 2.204  | 0.003 | 0.004 | 0.004 | 0.093 | 0.012  | 23.000    | 164943.000 | 96693935.000 | 150613.606 |
| 65    | 0   | 65  | 0   | 0   | 0   | POST   | /session                                                | 0.001 | 0.018 | 0.202  | 0.003 | 0.004 | 0.004 | 0.018 | 0.002  | 48.000    | 48.000     | 3120.000     | 48.000     |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/layout-a447854c3bff4fcd.js     | 0.001 | 0.012 | 0.180  | 0.003 | 0.005 | 0.007 | 0.012 | 0.002  | 1054.000  | 1054.000   | 68510.000    | 1054.000   |
| 121   | 0   | 121 | 0   | 0   | 0   | GET    | /login                                                  | 0.001 | 0.068 | 0.333  | 0.003 | 0.003 | 0.004 | 0.004 | 0.006  | 1262.000  | 1877.000   | 193292.000   | 1597.455   |
| 138   | 0   | 138 | 0   | 0   | 0   | GET    | /api/order/[0-9]*                                       | 0.001 | 0.011 | 0.372  | 0.003 | 0.004 | 0.005 | 0.007 | 0.001  | 313.000   | 7304.000   | 254975.000   | 1847.645   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/main-app-aad39d0b947a2963.js       | 0.001 | 0.016 | 0.172  | 0.003 | 0.004 | 0.006 | 0.016 | 0.002  | 460.000   | 460.000    | 29900.000    | 460.000    |
| 55    | 0   | 55  | 0   | 0   | 0   | DELETE | /session                                                | 0.001 | 0.005 | 0.142  | 0.003 | 0.004 | 0.004 | 0.005 | 0.001  | 51.000    | 51.000     | 2805.000     | 51.000     |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/765-53bf182bd94b7b47.js            | 0.001 | 0.008 | 0.160  | 0.002 | 0.003 | 0.004 | 0.008 | 0.001  | 3535.000  | 3535.000   | 229775.000   | 3535.000   |
| 55    | 0   | 55  | 0   | 0   | 0   | GET    | /session                                                | 0.001 | 0.005 | 0.130  | 0.002 | 0.003 | 0.003 | 0.005 | 0.001  | 156.000   | 158.000    | 8604.000     | 156.436    |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/webpack-137ac530a47d8278.js        | 0.001 | 0.015 | 0.152  | 0.002 | 0.004 | 0.005 | 0.015 | 0.002  | 1757.000  | 1757.000   | 114205.000   | 1757.000   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/error-20d09d53a3e47e92.js      | 0.001 | 0.011 | 0.109  | 0.002 | 0.003 | 0.005 | 0.011 | 0.002  | 599.000   | 599.000    | 38935.000    | 599.000    |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/chunks/app/page-8264df3e0d0b83d9.js       | 0.001 | 0.005 | 0.097  | 0.001 | 0.002 | 0.003 | 0.005 | 0.001  | 1292.000  | 1292.000   | 83980.000    | 1292.000   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/css/7c24bb46fac18203.css                  | 0.001 | 0.007 | 0.094  | 0.001 | 0.002 | 0.003 | 0.007 | 0.001  | 1094.000  | 1094.000   | 71110.000    | 1094.000   |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/media/c9a5bc6a7c948fb0-s.p.woff2          | 0.001 | 0.005 | 0.076  | 0.001 | 0.002 | 0.002 | 0.005 | 0.001  | 46552.000 | 46552.000  | 3025880.000  | 46552.000  |
| 65    | 0   | 65  | 0   | 0   | 0   | GET    | /_next/static/css/53792c77bc0423ee.css                  | 0.001 | 0.006 | 0.067  | 0.001 | 0.002 | 0.002 | 0.006 | 0.001  | 932.000   | 932.000    | 60580.000    | 932.000    |
| 3     | 0   | 3   | 0   | 0   | 0   | GET    | /api/tow_truck/1                                        | 0.001 | 0.001 | 0.003  | 0.001 | 0.001 | 0.001 | 0.001 | 0.000  | 102.000   | 102.000    | 306.000      | 102.000    |
| 1     | 0   | 0   | 0   | 1   | 0   | GET    | /api/tow_truck/100000000                                | 0.001 | 0.001 | 0.001  | 0.001 | 0.001 | 0.001 | 0.001 | 0.000  | 0.000     | 0.000      | 0.000        | 0.000      |
+-------+-----+-----+-----+-----+-----+--------+---------------------------------------------------------+-------+-------+--------+-------+-------+-------+-------+--------+-----------+------------+--------------+------------+
```

```
# 280ms user time, 30ms system time, 35.38M rss, 391.99G vsz
# Current date: Sat Jul 27 20:48:22 2024
# Hostname: MacBook.local
# Files: slow.log
# Overall: 5.62k total, 43 unique, 10.87 QPS, 0.02x concurrency __________
# Time range: 2024-07-27T11:38:55 to 2024-07-27T11:47:32
# Attribute          total     min     max     avg     95%  stddev  median
# ============     ======= ======= ======= ======= ======= ======= =======
# Exec time            12s     2us      2s     2ms    21ms    28ms    49us
# Lock time           23ms       0    20ms     4us     1us   266us       0
# Rows sent        845.23k       0  48.83k  153.98    0.99   2.15k       0
# Rows examine       5.09M       0   2.49M  948.70   1.20k  32.56k       0
# Query size       355.72k      11   1.28k   64.80  130.47  151.67   26.08

# Profile
# Rank Query ID                            Response time Calls R/Call V/M
# ==== =================================== ============= ===== ====== ====
#    1 0x031847BDCB4ADEF6F0635C123B7461D4   2.0753 17.3%     1 2.0753  0.00 UPDATE SELECT tow_trucks locations
#    2 0x6B1CA44888341BCBADC7E7D6C44D41B5   1.7723 14.8%    73 0.0243  0.00 INSERT sessions
#    3 0x8A3E4B6435519E43C2B8B8E135E99668   1.4776 12.3%    65 0.0227  0.00 INSERT completed_orders
#    4 0x45DCEA13C4252CE30BAABA0BACD76CBC   1.4647 12.2%    58 0.0253  0.00 UPDATE orders
#    5 0x04BBD25509FE01B133EB50DCE5E01990   1.4113 11.8%    57 0.0248  0.00 DELETE sessions
#    6 0xC723F48BCC895E734B69049287D2F63C   1.3681 11.4%    58 0.0236  0.00 UPDATE tow_trucks
#    7 0xF3D90F2F70D70848EA75F9D3300BF7BD   1.1393  9.5%    66 0.0173  0.04 SELECT edges nodes
#    8 0xD54A281FB93595B0456A5C68CBA58B59   0.2491  2.1%    66 0.0038  0.00 SELECT nodes
#    9 0x233F8C4D8BD838F839E325753BEF0E02   0.2304  1.9%     9 0.0256  0.00 UPDATE tow_trucks
#   10 0xE8390778DC20D4CC04FE01C5B31FD305   0.1363  1.1%  3388 0.0000  0.00 ADMIN PING
#   11 0x6F4DCC2FA6E75F6BE278DF1C250A7022   0.1083  0.9%    69 0.0016  0.00 SELECT orders nodes users dispatchers users tow_trucks users
# MISC 0xMISC                               0.5755  4.8%  1711 0.0003   0.0 <32 ITEMS>

# Query 1: 0 QPS, 0x concurrency, ID 0x031847BDCB4ADEF6F0635C123B7461D4 at byte 752
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: all events occurred at 2024-07-27T11:39:13
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0       1
# Exec time     17      2s      2s      2s      2s      2s       0      2s
# Lock time      0     5us     5us     5us     5us     5us       0     5us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine  48   2.49M   2.49M   2.49M   2.49M   2.49M       0   2.49M
# Query size     0     280     280     280     280     280       0     280
# String:
# Databases    42tokyo-db
# Hosts        localhost
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms
# 100ms
#    1s  ################################################################
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'tow_trucks'\G
#    SHOW CREATE TABLE `42tokyo-db`.`tow_trucks`\G
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'locations'\G
#    SHOW CREATE TABLE `42tokyo-db`.`locations`\G
UPDATE tow_trucks tt
JOIN (
    SELECT tow_truck_id, node_id
    FROM locations
    WHERE (tow_truck_id, timestamp) IN (
        SELECT tow_truck_id, MAX(timestamp)
        FROM locations
        GROUP BY tow_truck_id
    )
) l ON tt.id = l.tow_truck_id
SET tt.node_id = l.node_id\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select  tt.node_id = l.node_id from tow_trucks tt
JOIN (
    SELECT tow_truck_id, node_id
    FROM locations
    WHERE (tow_truck_id, timestamp) IN (
        SELECT tow_truck_id, MAX(timestamp)
        FROM locations
        GROUP BY tow_truck_id
    )
) l ON tt.id = l.tow_truck_id \G

# Query 2: 0.40 QPS, 0.01x concurrency, ID 0x6B1CA44888341BCBADC7E7D6C44D41B5 at byte 968781
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-07-27T11:39:16 to 2024-07-27T11:42:20
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1      73
# Exec time     14      2s    20ms    59ms    24ms    31ms     6ms    22ms
# Lock time      0   138us     1us     4us     1us     2us       0     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     1   6.77k      90      95   94.93   92.72    0.51   92.72
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'sessions'\G
#    SHOW CREATE TABLE `42tokyo-db`.`sessions`\G
INSERT INTO sessions (user_id, session_token) VALUES (101356, 'uRJRG8MhgDblLgyIDG5uI86MfrABGH')\G

# Query 3: 0.35 QPS, 0.01x concurrency, ID 0x8A3E4B6435519E43C2B8B8E135E99668 at byte 378073
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-07-27T11:39:17 to 2024-07-27T11:42:25
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1      65
# Exec time     12      1s    10ms    35ms    23ms    31ms     5ms    22ms
# Lock time      0    79us       0     4us     1us     1us       0     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     2   7.40k     113     119  116.51  118.34    2.11  112.70
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'completed_orders'\G
#    SHOW CREATE TABLE `42tokyo-db`.`completed_orders`\G
INSERT INTO completed_orders (order_id, tow_truck_id, completed_time) VALUES (77, 100, '2024-07-27 11:40:30.767000')\G

# Query 4: 0.31 QPS, 0.01x concurrency, ID 0x45DCEA13C4252CE30BAABA0BACD76CBC at byte 601779
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-07-27T11:39:17 to 2024-07-27T11:42:25
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1      58
# Exec time     12      1s    20ms    70ms    25ms    36ms     8ms    21ms
# Lock time      0    69us     1us     2us     1us     1us       0     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0      58       1       1       1       1       0       1
# Query size     1   5.32k      89      97   93.86   92.72    2.14   92.72
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'orders'\G
#    SHOW CREATE TABLE `42tokyo-db`.`orders`\G
UPDATE orders SET dispatcher_id = 43, tow_truck_id = 361, status = 'dispatched' WHERE id = 172\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select  dispatcher_id = 43, tow_truck_id = 361, status = 'dispatched' from orders where  id = 172\G

# Query 5: 0.32 QPS, 0.01x concurrency, ID 0x04BBD25509FE01B133EB50DCE5E01990 at byte 859102
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-07-27T11:39:25 to 2024-07-27T11:42:25
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1      57
# Exec time     11      1s    18ms    42ms    25ms    34ms     5ms    22ms
# Lock time     86    20ms     1us    20ms   353us     5us     3ms     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0     857       8      19   15.04   18.53    3.30   15.25
# Query size     1   4.17k      75      75      75      75       0      75
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'sessions'\G
#    SHOW CREATE TABLE `42tokyo-db`.`sessions`\G
DELETE FROM sessions WHERE session_token = 'FFLcFE9dkdhta7CL2vzy6oMLijxaZa'\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select * from  sessions WHERE session_token = 'FFLcFE9dkdhta7CL2vzy6oMLijxaZa'\G

# Query 6: 0.31 QPS, 0.01x concurrency, ID 0xC723F48BCC895E734B69049287D2F63C at byte 780794
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-07-27T11:39:17 to 2024-07-27T11:42:25
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1      58
# Exec time     11      1s    17ms    51ms    24ms    30ms     5ms    21ms
# Lock time      0    68us     1us     2us     1us     1us       0     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0      58       1       1       1       1       0       1
# Query size     0   2.94k      50      53   51.84   51.63    1.19   51.63
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'tow_trucks'\G
#    SHOW CREATE TABLE `42tokyo-db`.`tow_trucks`\G
UPDATE tow_trucks SET status = 'busy' WHERE id = 81\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select  status = 'busy' from tow_trucks where  id = 81\G

# Query 7: 0.35 QPS, 0.01x concurrency, ID 0xF3D90F2F70D70848EA75F9D3300BF7BD at byte 1041229
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.04
# Time range: 2024-07-27T11:39:17 to 2024-07-27T11:42:24
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1      66
# Exec time      9      1s     2ms   137ms    17ms    61ms    26ms     5ms
# Lock time      0    95us     1us     4us     1us     1us       0     1us
# Rows sent     81 691.93k      20  48.83k  10.48k  46.68k  16.71k   1.86k
# Rows examine  28   1.45M  11.96k  60.77k  22.43k  59.57k  17.13k  13.78k
# Query size     3  12.70k     197     197     197     197       0     197
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  #################################
# 100ms  ###
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'edges'\G
#    SHOW CREATE TABLE `42tokyo-db`.`edges`\G
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'nodes'\G
#    SHOW CREATE TABLE `42tokyo-db`.`nodes`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT
                e.node_a_id,
                e.node_b_id,
                e.weight
            FROM
                edges e
            JOIN nodes n ON e.node_a_id = n.id WHERE n.area_id = 7\G

# Query 8: 0.35 QPS, 0.00x concurrency, ID 0xD54A281FB93595B0456A5C68CBA58B59 at byte 1290373
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-07-27T11:39:17 to 2024-07-27T11:42:23
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1      66
# Exec time      2   249ms     3ms    10ms     4ms     7ms     2ms     3ms
# Lock time      0    72us       0     2us     1us     1us       0     1us
# Rows sent     15 133.30k      10   9.77k   2.02k   9.33k   3.33k  964.41
# Rows examine  15 788.26k  11.94k  11.94k  11.94k  11.94k       0  11.94k
# Query size     2   8.64k     134     134     134     134       0     134
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms  #
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'nodes'\G
#    SHOW CREATE TABLE `42tokyo-db`.`nodes`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT
                *
            FROM
                nodes
            WHERE area_id = 7
            ORDER BY
                id\G

# Query 9: 0 QPS, 0x concurrency, ID 0x233F8C4D8BD838F839E325753BEF0E02 at byte 77655
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: all events occurred at 2024-07-27T11:39:17
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0       9
# Exec time      1   230ms    22ms    32ms    26ms    31ms     3ms    24ms
# Lock time      0     9us     1us     1us     1us     1us       0     1us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       9       1       1       1       1       0       1
# Query size     0     415      46      47   46.11   46.83    0.50   44.60
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms  ################################################################
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'tow_trucks'\G
#    SHOW CREATE TABLE `42tokyo-db`.`tow_trucks`\G
UPDATE tow_trucks SET node_id = 4 WHERE id = 5\G
# Converted for EXPLAIN
# EXPLAIN /*!50100 PARTITIONS*/
select  node_id = 4 from tow_trucks where  id = 5\G

# Query 10: 17.83 QPS, 0.00x concurrency, ID 0xE8390778DC20D4CC04FE01C5B31FD305 at byte 171177
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-07-27T11:39:15 to 2024-07-27T11:42:25
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         60    3388
# Exec time      1   136ms    19us   364us    40us    63us    15us    36us
# Lock time      0       0       0       0       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size    25  89.33k      27      27      27      27       0      27
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us  ################################################################
# 100us  #
#   1ms
#  10ms
# 100ms
#    1s
#  10s+
administrator command: Ping\G

# Query 11: 0.38 QPS, 0.00x concurrency, ID 0x6F4DCC2FA6E75F6BE278DF1C250A7022 at byte 45456
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: 2024-07-27T11:39:17 to 2024-07-27T11:42:20
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          1      69
# Exec time      0   108ms     1ms     3ms     2ms     3ms   511us     1ms
# Lock time      0   162us     1us     4us     2us     2us       0     1us
# Rows sent      0     680       6      10    9.86    9.83    0.64    9.83
# Rows examine   3 156.76k   1.62k   4.44k   2.27k   4.27k  806.71   1.69k
# Query size    24  88.61k   1.28k   1.28k   1.28k   1.28k       0   1.28k
# String:
# Databases    42tokyo-db
# Hosts        172.18.0.3
# Users        user
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms  ################################################################
#  10ms
# 100ms
#    1s
#  10s+
# Tables
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'orders'\G
#    SHOW CREATE TABLE `42tokyo-db`.`orders`\G
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'nodes'\G
#    SHOW CREATE TABLE `42tokyo-db`.`nodes`\G
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'users'\G
#    SHOW CREATE TABLE `42tokyo-db`.`users`\G
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'dispatchers'\G
#    SHOW CREATE TABLE `42tokyo-db`.`dispatchers`\G
#    SHOW TABLE STATUS FROM `42tokyo-db` LIKE 'tow_trucks'\G
#    SHOW CREATE TABLE `42tokyo-db`.`tow_trucks`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT
                o.id,
                o.client_id,
                cu.username as client_username,
                o.dispatcher_id,
                d.user_id as dispatcher_user_id,
                diu.username as dispatcher_username,
                o.tow_truck_id,
                dru.id as driver_user_id,
                dru.username as driver_username,
                n.area_id as area_id,
                o.status,
                o.node_id,
                o.car_value,
                o.order_time,
                o.completed_time
            FROM
                orders o
            JOIN
                nodes n
            ON
                o.node_id = n.id
            JOIN
                users cu
            ON
                o.client_id = cu.id
            LEFT JOIN
                dispatchers d
            ON
                o.dispatcher_id = d.id
            LEFT JOIN
                users diu
            ON
                d.user_id = diu.id
            LEFT JOIN
                tow_trucks t
            ON
                o.tow_truck_id = t.id
            LEFT JOIN
                users dru
            ON
                t.driver_id = dru.id
            WHERE o.status = 'pending' AND n.area_id = 1
            ORDER BY o.order_time ASC
            LIMIT 10
            OFFSET 0\G
```